### PR TITLE
GetMethodDefinition returns get_Property method definition

### DIFF
--- a/GrEmit/GrEmit/Utils/HackHelpers.cs
+++ b/GrEmit/GrEmit/Utils/HackHelpers.cs
@@ -222,6 +222,10 @@ namespace GrEmit.Utils
             var methodCallExpression = body as MethodCallExpression;
             if(methodCallExpression != null)
                 return (methodCallExpression).Method;
+            var memberExpression = body as MemberExpression;
+            var propertyInfo = memberExpression?.Member as PropertyInfo;
+            if(propertyInfo != null)
+                return propertyInfo.GetMethod;
             throw new InvalidOperationException("unknown expression " + body);
         }
     }

--- a/GrEmit/Tests/HackHelpersTest.cs
+++ b/GrEmit/Tests/HackHelpersTest.cs
@@ -187,6 +187,8 @@ namespace Tests
             Assert.AreEqual(GetMethod(typeof(ClassWithMethods), "op_Addition", null),
                             HackHelpers.GetMethodDefinition<ClassWithMethods>(
                                 o => o + default(ClassWithMethods)));
+            Assert.AreEqual(GetMethod(typeof(ClassWithMethods), "get_P1", null),
+                HackHelpers.GetMethodDefinition<ClassWithMethods>(o => o.P1));
         }
 
         [Test]


### PR DESCRIPTION
Now possible to write this:
```csharp
HackHelpers.GetMethodDefinition<List<object>>(list => list.Count)
```