### PR TITLE
Remove check for by-ref value type on ldfld

### DIFF
--- a/GrEmit/StackMutators/CallStackMutator.cs
+++ b/GrEmit/StackMutators/CallStackMutator.cs
@@ -57,9 +57,7 @@ namespace GrEmit.StackMutators
                 var instanceBaseType = instance.ToType();
                 if (instanceBaseType != null)
                 {
-                    if (instanceBaseType.IsValueType)
-                        ThrowError(il, $"In order to call the method '{formattedMethodGetter()}' on a value type '{instance}' load an instance by ref or box it");
-                    else if (!instanceBaseType.IsByRef)
+                    if (!instanceBaseType.IsByRef)
                         CheckCanBeAssigned(il, declaringType, instance);
                     else
                     {

--- a/GrEmit/StackMutators/LdfldStackMutator.cs
+++ b/GrEmit/StackMutators/LdfldStackMutator.cs
@@ -16,9 +16,7 @@ namespace GrEmit.StackMutators
                 var instance = stack.Pop().ToType();
                 if (instance != null)
                 {
-                    if (instance.IsValueType)
-                        ThrowError(il, $"In order to load the field '{Formatter.Format(field)}' of a value type '{Formatter.Format(instance)}' load an instance by ref");
-                    else if (!instance.IsByRef)
+                    if (!instance.IsByRef)
                         CheckCanBeAssigned(il, declaringType, instance);
                     else
                     {


### PR DESCRIPTION
This check in the `ldfld` stack mutator was preventing an otherwise valid `ldfld` instruction from being emitted. I suppose there is a reason for this check to be here, but from what I can tell it's unnecessary, and even if it *was* supposed to be there it was preventing valid code from being emitted.